### PR TITLE
Fix for return type of [FMDatabase indexNamesOnTable:]

### DIFF
--- a/Sources/FMDatabase+FMDBHelpers.h
+++ b/Sources/FMDatabase+FMDBHelpers.h
@@ -206,7 +206,7 @@ withParameterDictionary:(NSDictionary *)parameters
 /**
  *  Returns the names of all indexes on a given table.
  */
-- (NSArray *)indexNamesOnTable:(NSString *)tableName;
+- (NSSet *)indexNamesOnTable:(NSString *)tableName;
 
 /**
  *  Creates a non-unique index on a table.


### PR DESCRIPTION
Thanks for the useful project!

I noticed this method was declared as an `NSArray`

```
/**
 *  Returns the names of all indexes on a given table.
 */
- (NSArray *)indexNamesOnTable:(NSString *)tableName;
```

but implemented as an `NSSet`

```
- (NSSet *)indexNamesOnTable:(NSString *)tableName
{
  FMResultSet * schema = [self getSchema];
  NSMutableSet * indexNames = [[NSMutableSet alloc] init];
  ...
  return indexNames;
}
```

I think `NSSet` is the right type. 
