### PR TITLE
Remove warning in [FMDatabaseQueue inDatabase:]

### DIFF
--- a/Sources/FMDatabase+FMDBHelpers.m
+++ b/Sources/FMDatabase+FMDBHelpers.m
@@ -575,11 +575,15 @@ withParameterDictionary:(NSDictionary *)arguments
   {
     if (sizeof(NSInteger) == sizeof(long))
     {
-      return [results longForColumnIndex:0];
+        long count = [results longForColumnIndex:0];
+        [results close];
+        return count;
     }
     else
     {
-      return [results intForColumnIndex:0];
+        int count = [results intForColumnIndex:0];
+        [results close];
+        return count;
     }
   }
   else


### PR DESCRIPTION
Remove "Warning: there is at least one open result set around after performing [FMDatabaseQueue inDatabase:]"
when calling

```
- (NSInteger)count:(NSArray *)columnNames from:(NSString *)from where:(NSString *)where arguments:(NSArray *)arguments error:(NSError **)error_p
using [FMDatabaseQueue inDatabase:]
```
